### PR TITLE
layer: Add max_events_per_span API

### DIFF
--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -34,6 +34,7 @@ const FIELD_EXCEPTION_STACKTRACE: &str = "exception.stacktrace";
 pub struct OpenTelemetryLayer<S, T> {
     tracer: T,
     location: bool,
+    max_events_per_span: Option<usize>,
     tracked_inactivity: bool,
     with_threads: bool,
     exception_config: ExceptionFieldConfig,
@@ -91,6 +92,30 @@ impl WithContext {
         mut f: impl FnMut(&mut OtelData, &dyn PreSampledTracer),
     ) {
         (self.0)(dispatch, id, &mut f)
+    }
+}
+
+/// Using [`OpenTelemetryLayer::max_events_per_span`] you can limit the number
+/// of [`otel::Event`]s that we'll record for a given span. If we exceed this
+/// limit we'll keep a count of how many events we've dropped.
+#[derive(Debug)]
+struct DroppedOtelEvents {
+    // how many events we've dropped thus far
+    dropped_count: usize,
+    // have we reported that events have been dropped
+    reported: bool,
+}
+
+impl DroppedOtelEvents {
+    fn new() -> Self {
+        DroppedOtelEvents {
+            dropped_count: 0,
+            reported: false,
+        }
+    }
+
+    fn add_dropped(&mut self, additional_count: usize) {
+        self.dropped_count = self.dropped_count.saturating_add(additional_count);
     }
 }
 
@@ -431,6 +456,7 @@ where
         OpenTelemetryLayer {
             tracer,
             location: true,
+            max_events_per_span: None,
             tracked_inactivity: true,
             with_threads: true,
             exception_config: ExceptionFieldConfig {
@@ -475,6 +501,7 @@ where
         OpenTelemetryLayer {
             tracer,
             location: self.location,
+            max_events_per_span: self.max_events_per_span,
             tracked_inactivity: self.tracked_inactivity,
             with_threads: self.with_threads,
             exception_config: self.exception_config,
@@ -581,6 +608,23 @@ where
     pub fn with_threads(self, threads: bool) -> Self {
         Self {
             with_threads: threads,
+            ..self
+        }
+    }
+
+    /// Sets the maximum number of [`otel::Event`] that we will store for any given
+    /// span. If we exceed this number, we will drop the first half of our buffered
+    /// events and maintain a count of events dropped thus far.
+    ///
+    /// By default, there is no maximum
+    ///
+    /// Note: This can be very useful when tracing at a `Debug` or `Trace` level. Some
+    /// crates (e.g. `h2`) maintain long living spans which result in events
+    /// continuously getting recorded, but never flushed. So in these cases you'd keep
+    /// buffering events until you run out of memory (OOM).
+    pub fn max_events_per_span(self, num: usize) -> Self {
+        Self {
+            max_events_per_span: Some(num),
             ..self
         }
     }
@@ -853,7 +897,9 @@ where
                 exception_config: self.exception_config,
             });
 
-            if let Some(OtelData { builder, .. }) = extensions.get_mut::<OtelData>() {
+            let dropped_events = if let Some(OtelData { builder, .. }) =
+                extensions.get_mut::<OtelData>()
+            {
                 if builder.status == otel::Status::Unset
                     && *meta.level() == tracing_core::Level::ERROR
                 {
@@ -896,6 +942,52 @@ where
                 } else {
                     builder.events = Some(vec![otel_event]);
                 }
+
+                // limit the maximum number of events we'll record per-span
+                match (self.max_events_per_span, &mut builder.events) {
+                    (Some(max_num_events), Some(ref mut events))
+                        if events.len() > max_num_events =>
+                    {
+                        // drain half of the existing events, using ceiling division
+                        // to handle the case where max_num_events is 0 or 1
+                        //
+                        // note: this should be more efficient than just continuously
+                        // popping the first element
+                        let num_events_to_drain = (events.len() + 2 - 1) / 2;
+                        events.drain(0..num_events_to_drain);
+
+                        Some(num_events_to_drain)
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            };
+
+            // record how many events we dropped
+            match (dropped_events, extensions.get_mut::<DroppedOtelEvents>()) {
+                (Some(additional_dropped), Some(current_dropped)) => {
+                    current_dropped.add_dropped(additional_dropped);
+
+                    // report, once per span, when we drop events
+                    if !current_dropped.reported {
+                        let id = span.id().into_u64();
+                        let name = span.name();
+                        let module = span.metadata().module_path();
+                        let line = span.metadata().line();
+
+                        tracing::error!(
+                            "Dropped events for span({id}) named: {name} at {module:?}:{line:?}"
+                        );
+                        current_dropped.reported = true;
+                    }
+                }
+                (Some(additional_dropped), None) => {
+                    let mut count = DroppedOtelEvents::new();
+                    count.add_dropped(additional_dropped);
+                    extensions.insert(count);
+                }
+                _ => (),
             }
         };
     }
@@ -987,6 +1079,7 @@ mod tests {
         time::SystemTime,
     };
     use tracing_subscriber::prelude::*;
+    use tracing_subscriber::registry::LookupSpan;
 
     #[derive(Debug, Clone)]
     struct TestTracer(Arc<Mutex<Option<OtelData>>>);
@@ -1385,5 +1478,148 @@ mod tests {
                 "base error".into(),
             ]))
         );
+    }
+
+    #[test]
+    fn tracks_dropped_events() {
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry()
+            .with(layer().with_tracer(tracer.clone()).max_events_per_span(4));
+        let subscriber = Arc::new(subscriber);
+
+        tracing::subscriber::with_default(subscriber.clone(), || {
+            let span = tracing::debug_span!("request");
+            let _span_guard = span.enter();
+
+            // we should record all 4 events
+            tracing::info!("event 1");
+            tracing::info!("event 2");
+            tracing::info!("event 3");
+            tracing::info!("event 4");
+
+            let data = span.id().and_then(|id| subscriber.span(&id)).unwrap();
+            let extensions = data.extensions();
+
+            // we shouldn't have recoreded any dropped events
+            assert!(extensions.get::<DroppedOtelEvents>().is_none());
+
+            // we should have all 4 events
+            let otel_data = extensions.get::<OtelData>().unwrap();
+            let otel_events = otel_data.builder.events.as_ref().unwrap();
+            assert_eq!(otel_events.len(), 4);
+
+            drop(extensions);
+            drop(data);
+
+            // record a 5th event, which is over our max of 4
+            tracing::info!("event 5");
+
+            let data = span.id().and_then(|id| subscriber.span(&id)).unwrap();
+            let extensions = data.extensions();
+
+            // since we're over our limit we should start dropping events
+            let dropped_events = extensions.get::<DroppedOtelEvents>().unwrap();
+            assert_eq!(dropped_events.dropped_count, 3);
+
+            let otel_data = extensions.get::<OtelData>().unwrap();
+            let otel_events = otel_data.builder.events.as_ref().unwrap();
+            // dropped 3, pushed one more
+            assert_eq!(otel_events.len(), 2);
+
+            drop(extensions);
+            drop(data);
+
+            // record many events!
+            for i in 6..99 {
+                tracing::info!("event {}", i);
+            }
+
+            let data = span.id().and_then(|id| subscriber.span(&id)).unwrap();
+            let extensions = data.extensions();
+
+            // we should have dropped a ton of events, and recorded that we did
+            let dropped_events = extensions.get::<DroppedOtelEvents>().unwrap();
+            assert_eq!(dropped_events.dropped_count, 96);
+
+            let otel_data = extensions.get::<OtelData>().unwrap();
+            let otel_events = otel_data.builder.events.as_ref().unwrap();
+            assert_eq!(otel_events.len(), 2);
+
+            // even though we pushed a ton of events, the capacity of our buffer
+            // should still be small
+            assert_eq!(otel_events.capacity(), 8);
+        });
+    }
+
+    #[test]
+    fn max_events_per_span_zero() {
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry()
+            .with(layer().with_tracer(tracer.clone()).max_events_per_span(0));
+        let subscriber = Arc::new(subscriber);
+
+        tracing::subscriber::with_default(subscriber.clone(), || {
+            let span = tracing::debug_span!("request");
+            let _span_guard = span.enter();
+
+            // record one event
+            tracing::info!("event 1");
+
+            let data = span.id().and_then(|id| subscriber.span(&id)).unwrap();
+            let extensions = data.extensions();
+
+            // it should immediately get dropped
+            let dropped_events = extensions.get::<DroppedOtelEvents>().unwrap();
+            assert_eq!(dropped_events.dropped_count, 1);
+
+            let otel_data = extensions.get::<OtelData>().unwrap();
+            let otel_events = otel_data.builder.events.as_ref().unwrap();
+            assert!(otel_events.is_empty());
+        });
+    }
+
+    #[test]
+    fn max_events_per_span_one() {
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry()
+            .with(layer().with_tracer(tracer.clone()).max_events_per_span(1));
+        let subscriber = Arc::new(subscriber);
+
+        tracing::subscriber::with_default(subscriber.clone(), || {
+            let span = tracing::debug_span!("request");
+            let _span_guard = span.enter();
+
+            // record one event
+            tracing::info!("event 1");
+
+            let data = span.id().and_then(|id| subscriber.span(&id)).unwrap();
+            let extensions = data.extensions();
+
+            // we shouldn't have recoreded any dropped events
+            assert!(extensions.get::<DroppedOtelEvents>().is_none());
+
+            // we should have the event
+            let otel_data = extensions.get::<OtelData>().unwrap();
+            let otel_events = otel_data.builder.events.as_ref().unwrap();
+            assert_eq!(otel_events.len(), 1);
+
+            drop(extensions);
+            drop(data);
+
+            // record one more, we should drop the original
+            tracing::info!("event 2");
+
+            let data = span.id().and_then(|id| subscriber.span(&id)).unwrap();
+            let extensions = data.extensions();
+
+            // we shouldn't have recoreded any dropped events
+            let dropped_events = extensions.get::<DroppedOtelEvents>().unwrap();
+            assert_eq!(dropped_events.dropped_count, 1);
+
+            // we should have just one event
+            let otel_data = extensions.get::<OtelData>().unwrap();
+            let otel_events = otel_data.builder.events.as_ref().unwrap();
+            assert_eq!(otel_events.len(), 1);
+        });
     }
 }

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -1593,8 +1593,7 @@ mod tests {
     #[test]
     fn exclude_max_events_per_span() {
         let tracer = TestTracer(Arc::new(Mutex::new(None)));
-        let subscriber = tracing_subscriber::registry()
-            .with(layer().with_tracer(tracer.clone()));
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
         let subscriber = Arc::new(subscriber);
 
         tracing::subscriber::with_default(subscriber.clone(), || {


### PR DESCRIPTION
## Motivation
As described in https://github.com/MaterializeInc/database-issues/issues/5082, there is a slow OOM when enabling open-telemetry tracing at the debug level. Through some investigation it turns out this OOM is caused by an underlying library, `h2`, having a long running span. Specifically, `h2` keeps a debug span open for the entire lifetime of a `Connection`. This is problematic because the `OpenTelemetryLayer` continuously appends events onto this span, and we don't flush them until the span closes, which is never does, so we end up using more and more memory until we OOM.

## Solution
This PR adds a new configurable field to `OpenTelemetryLayer` that allows you to configure the maximum number of `otel::Event`s that will be recorded for a single span. When we go over this max we drop the oldest events, and report that events were dropped.
